### PR TITLE
Update and rename Hardhat.yml to ci-web3-gamefi.yml

### DIFF
--- a/.circleci/ci-web3-gamefi.yml
+++ b/.circleci/ci-web3-gamefi.yml
@@ -8,7 +8,7 @@ executors:
       - image: cimg/base:stable
         auth:
           # ensure you have first added these secrets
-          # visit app.circleci.com/settings/project/github/Dargon789/hardhat-project/environment-variables
+           # visit app.circleci.com/settings/project/github/Dargon789/foundry/environment-variables
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
 jobs:


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

## Summary by Sourcery

Rename the CircleCI configuration file for the web3 GameFi project and update the referenced CircleCI project URL in the Docker auth comment.

CI:
- Rename the CircleCI config from Hardhat.yml to ci-web3-gamefi.yml to reflect the web3 GameFi project.
- Update the CircleCI settings URL in the config comment to point to the correct GitHub project for environment variables.