### PR TITLE
Update cli-minikit.yml

### DIFF
--- a/.github/workflows/cli-minikit.yml
+++ b/.github/workflows/cli-minikit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - alpha
     paths:
       - 'packages/create-onchain/**'
   push:
@@ -12,6 +13,7 @@ on:
 
 jobs:
   test:
+    if: github.head_ref != 'alpha'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,10 +50,11 @@ jobs:
         run: |
           mkdir test-project
           cd test-project
+          
           (sleep 1; echo ""; sleep 1; echo ""; sleep 1; echo -e "\033[D\n"; sleep 1; echo -e "\033[D\n") | ../packages/create-onchain/dist/esm/cli.js --mini
 
       - name: Install & Build test project
-        working-directory: ./test-project/my-minikit-app
+        working-directory: ./test-project/my-onchainkit-app
         run: |
           npm install
           npm run build


### PR DESCRIPTION
ai help pin sha https://github.com/Dargon789/onchainkit/commit/73332291e6af197ea2650061ad5cf3cfe1ec4b30

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**

## Summary by Sourcery

Update the CLI minikit GitHub Actions workflow to run on the alpha branch and adjust test conditions and paths accordingly.

CI:
- Trigger the cli-minikit workflow on pull requests targeting the alpha branch in addition to main.
- Skip the test job when the pull request head branch is alpha.
- Update the test workflow to use the new generated project directory name for the sample app.