### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG] '
-labels: 'bug'
+title: ''
+labels: ''
 assignees: ''
 
 ---
@@ -25,15 +25,12 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]
- - Browser [e.g. Chrome, Safari]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone 6]
+ - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, Safari]
- - Version [e.g. 22]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,13 +1,10 @@
 ---
-name: General Issue
-about: For issues that don't fit other categories
+name: Custom issue template
+about: Describe this issue template's purpose here.
 title: ''
-labels: 'discussion'
+labels: ''
 assignees: ''
 
 ---
 
-### Description
-
-*Provide a clear and concise description of your issue or suggestion.*
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[FEAT] '
-labels: 'enhancement'
+title: ''
+labels: ''
 assignees: ''
 
 ---


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub issue templates to use neutral defaults and generic prompts without preset titles or labels.

Documentation:
- Revise bug report and feature request templates to remove default title/label prefixes and standardize example text.
- Rename and generalize the custom issue template with a more generic description and no default labels.