### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/miniapp-manifest-test.yml
+++ b/.github/workflows/miniapp-manifest-test.yml
@@ -1,5 +1,8 @@
 name: manifest test:coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/onchainkit/security/code-scanning/29](https://github.com/Dargon789/onchainkit/security/code-scanning/29)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix (without changing functionality): add at workflow root (near `name`/`on`) so it applies to all jobs unless overridden. For this workflow, `contents: read` is the minimal appropriate permission for checkout and test execution.

File to change:
- `.github/workflows/miniapp-manifest-test.yml`

Change region:
- Insert `permissions:` between `name:` and `on:` (or directly under `on:`), with:
  - `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a workflow-level permissions block granting only read access to repository contents for the miniapp manifest test workflow.